### PR TITLE
Add Drupal root to to Twig template paths

### DIFF
--- a/twigshim.module
+++ b/twigshim.module
@@ -71,14 +71,6 @@ function twigshim_render($template, $variables = array()) {
       $templates = "$theme_path/templates";
     }
 
-    // Create a twig worker.
-    $loader = new Twig_Loader_Filesystem(DRUPAL_ROOT . base_path() . $templates);
-
-    // Add Drupal's web root so that we can provide relative template paths
-    // from the Drupal root. For example:
-    //     sites/all/modules/contrib/twigshim/twigshim.example.html.twig
-    $loader->addPath(DRUPAL_ROOT);
-
     // Define the Twig options.
     $options['debug'] = variable_get('twigshim_debug', FALSE);
     $options['autoescape'] = FALSE;
@@ -87,7 +79,11 @@ function twigshim_render($template, $variables = array()) {
       $options['cache'] = $files_dir . '/twig';
     }
 
-    // Create the Twig Environment.
+    // Create a Twig worker.
+    $loader = new Twig_Loader_Filesystem(array(
+      DRUPAL_ROOT,
+      DRUPAL_ROOT . "/$templates",
+    ));
     $twig = new Twig_Environment($loader, $options);
   }
 


### PR DESCRIPTION
This can be done all at once in the constructor instead of via `addPath()` ([reference](http://twig.sensiolabs.org/api/master/Twig_Loader_Filesystem.html#method___construct)).