### PR TITLE
Remove minimum-stability "dev"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Shoehorns Twig template compiling into Drupal 7.",
     "type": "project",
     "require": {
-        "twig/twig": "~1.0"
+        "twig/twig": "~1.29"
     },
     "license": "MIT",
     "authors": [
@@ -11,6 +11,5 @@
             "name": "Derek DeRaps",
             "email": "derek@kalamuna.com"
         }
-    ],
-    "minimum-stability": "dev"
+    ]
 }


### PR DESCRIPTION
It can have adverse affects on semantic versioning.